### PR TITLE
Updates consult marker call

### DIFF
--- a/consult-ag.el
+++ b/consult-ag.el
@@ -48,7 +48,7 @@ FIND-FILE is the file open function, defaulting to `find-file`."
     (let ((file (get-text-property 0 'filename cand))
           (row (string-to-number (get-text-property 0 'row cand)))
           (column (- (string-to-number (get-text-property 0 'column cand)) 1)))
-      (consult--position-marker (funcall (or find-file #'find-file) file) row column))))
+      (consult--marker-from-line-column (funcall (or find-file #'find-file) file) row column))))
 
 (defun consult-ag--grep-state ()
   "Not documented."


### PR DESCRIPTION
Resolves #7 caused by changes in minad/consult where the marker call function name is changed from `consult--position-marker` to `consult--marker-from-line-column`.


https://github.com/minad/consult/commit/c21302c03881aeb940343c7fec4fcb819d5fc381